### PR TITLE
PR: Add legacy Joystick class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ find_package(SDL2)
 add_definitions(-DUNIT_LIB_DISABLE_FMT -DUNIT_LIB_ENABLE_IOSTREAM)
 
 # Add all CPP files to the executable
-add_executable(${PROJECT_NAME} main.cpp RobotBase.cpp GameController.cpp)
+# Note: Users using GameController should swap out Joystick.cpp with GameController.cpp
+add_executable(${PROJECT_NAME} main.cpp RobotBase.cpp Joystick.cpp)
 
 # Specify libraries to link against
 target_link_libraries(${PROJECT_NAME} phoenix-pro)

--- a/GameController.hpp
+++ b/GameController.hpp
@@ -8,6 +8,8 @@
 
 /**
  * Manages a game controller using the SDL 2 library.
+ *
+ * Note: This requires Ubuntu 22.04+ or Debian Bullseye.
  */
 class GameController {
 private:
@@ -122,7 +124,7 @@ public:
     double GetAxis(SDL_GameControllerAxis axis) const
     {
         if (_joy) {
-            return SDL_GameControllerGetAxis(_joy, axis) / 32767.0;
+            return SDL_GameControllerGetAxis(_joy, axis) / 32768.0;
         } else {
             return 0.0;
         }

--- a/Joystick.cpp
+++ b/Joystick.cpp
@@ -1,0 +1,80 @@
+#include "Joystick.hpp"
+
+/*static*/ std::mutex Joystick::s_joyCntLck;
+/*static*/ uint64_t Joystick::s_joyCnt{0};
+
+bool Joystick::IsConnected() const
+{
+    if (!_joy) {
+        /* no joystick */
+        return false;
+    }
+
+    /* poll for joystick disconnects */
+    SDL_Event event;
+    if (SDL_PollEvent(&event)) {
+        if (event.type == SDL_QUIT) {
+            /* SDL shut down */
+            return false;
+        }
+        else if (event.cdevice.type == SDL_JOYDEVICEREMOVED) {
+            /* SDL joystick removed */
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void Joystick::ReportMissingJoystick()
+{
+    auto const now = std::chrono::steady_clock::now();
+    auto const dtMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastErrorTime).count();
+
+    if (dtMs > kErrorTimeMs) {
+        fprintf(stderr, "Warning: Could not find joystick on port %d\n", _port);
+        _lastErrorTime = now;
+    }
+}
+
+SDL_Joystick *Joystick::CreateJoystick()
+{
+    /* SDL seems somewhat fragile, shut it down and bring it up */
+    SDL_Quit();
+    SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1"); // so Ctrl-C still works
+    SDL_Init(SDL_INIT_GAMECONTROLLER);
+
+    /* poll for joysticks */
+    int res = SDL_NumJoysticks();
+    if (res < 0) {
+        /* error trying to get joysticks */
+        fprintf(stderr, "Error getting joysticks: %d\n", res);
+        ReportMissingJoystick();
+        return nullptr;
+    } else if (res <= _port) {
+        /* not enough joysticks for given port */
+        ReportMissingJoystick();
+        return nullptr;
+    }
+
+    /* joystick found */
+    return SDL_JoystickOpen(_port);
+}
+
+void Joystick::PrintJoystickInfo() const
+{
+    /* Get information about the joystick */
+    auto const name = GetName();
+    auto const num_axes = GetNumAxes();
+    auto const num_buttons = GetNumButtons();
+    auto const num_hats = GetNumHats();
+
+    /* print information */
+    printf("Connected to joystick '%s'\n"
+            "    Port: %d\n"
+            "    Num Axes: %d\n"
+            "    Num Buttons: %d\n"
+            "    Num Hats: %d\n",
+            name.c_str(), _port,
+            num_axes, num_buttons, num_hats);
+}

--- a/Joystick.hpp
+++ b/Joystick.hpp
@@ -1,0 +1,205 @@
+#pragma once
+
+#include <SDL2/SDL.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <chrono>
+#include <mutex>
+
+/**
+ * Manages a joystick using the SDL 2 library.
+ *
+ * Note: This is a legacy class for users on Ubuntu
+ *       20.04 and older. Users on newer systems
+ *       can use the GameController class.
+ */
+class Joystick {
+private:
+    SDL_Joystick *_joy = nullptr;
+    int _port;
+
+    static std::mutex s_joyCntLck;
+    static uint64_t s_joyCnt;
+
+    /** Initialize this joystick. */
+    void Init()
+    {
+        if (_joy) {
+            /* close any existing joystick first */
+            Close();
+        }
+
+        _joy = CreateJoystick();
+        if (_joy) {
+            /* Print information about the joystick */
+            PrintJoystickInfo();
+        }
+    }
+
+    /** Closes this joystick. */
+    void Close()
+    {
+        /* do nothing if no joystick */
+        if (!_joy) return;
+
+        SDL_JoystickClose(_joy);
+        _joy = nullptr;
+    }
+
+public:
+    /**
+     * Creates a joystick on the given port.
+     */
+    Joystick(int port) : _port{port}
+    {
+        /* first increment joystick count */
+        {
+            std::lock_guard lck{s_joyCntLck};
+            ++s_joyCnt;
+        }
+
+        /* then initialize this joystick */
+        Init();
+    }
+
+    ~Joystick()
+    {
+        /* first close this joystick */
+        Close();
+
+        /* then decrement joystick count */
+        {
+            std::lock_guard lck{s_joyCntLck};
+            if (--s_joyCnt == 0) {
+                /* this was the last joystick, quit SDL */
+                SDL_Quit();
+            }
+        }
+    }
+
+    /**
+     * Returns the port of this joystick.
+     */
+    int GetPort() const { return _port; }
+
+    /**
+     * Returns the name of this joystick.
+     */
+    std::string GetName() const
+    {
+        if (_joy) {
+            return SDL_GameControllerName(_joy);
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Returns the SDL type of this joystick.
+     */
+    SDL_JoystickType GetType() const
+    {
+        if (_joy) {
+            return SDL_JoystickGetType(_joy);
+        } else {
+            return SDL_JOYSTICK_TYPE_UNKNOWN;
+        }
+    }
+
+    /**
+     * Returns the number of buttons on this joystick.
+     */
+    int GetNumButtons() const
+    {
+        if (_joy) {
+            return SDL_JoystickNumButtons(_joy);
+        } else {
+            return -1;
+        }
+    }
+
+    /**
+     * Returns the number of axes on this joystick.
+     */
+    int GetNumAxes() const
+    {
+        if (_joy) {
+            return SDL_JoystickNumAxes(_joy);
+        } else {
+            return -1;
+        }
+    }
+
+    /**
+     * Returns the number of hats on this joystick.
+     */
+    int GetNumHats() const
+    {
+        if (_joy) {
+            return SDL_JoystickNumHats(_joy);
+        } else {
+            return -1;
+        }
+    }
+
+    /**
+     * Returns true if the given button is pressed,
+     * false otherwise or in the case of an error.
+     */
+    bool GetButton(int button) const
+    {
+        if (_joy) {
+            return SDL_JoystickGetButton(_joy, button);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the value of the given axis from
+     * -1.0 to 1.0, or 0 in the case of an error.
+     */
+    double GetAxis(int axis) const
+    {
+        if (_joy) {
+            return SDL_JoystickGetAxis(_joy, axis) / 32768.0;
+        } else {
+            return 0.0;
+        }
+    }
+
+    /**
+     * Returns whether this joystick is currently connected.
+     */
+    bool IsConnected() const;
+
+    /**
+     * Periodically manages this joystick, handling disconnect
+     * events in the process.
+     */
+    void Periodic()
+    {
+        /* poll for joystick disconnects */
+        if (!IsConnected()) {
+            /* one of the joysticks disconnected, assume it was ours */
+            Close();
+        }
+
+        /* joystick may have disconnected, make sure it's still valid */
+        if (!_joy) {
+            /* no joystick, initialize a new one */
+            Init();
+        }
+    }
+
+private:
+    static constexpr auto kErrorTimeMs = 2000;
+    std::chrono::time_point<std::chrono::steady_clock> _lastErrorTime = std::chrono::steady_clock::now();
+
+    /** Reports a missing joystick with debouncing. */
+    void ReportMissingJoystick();
+    /** Creates and returns a joystick. */
+    SDL_Joystick *CreateJoystick();
+    /** Prints out information about this joystick. */
+    void PrintJoystickInfo() const;
+};

--- a/Joystick.hpp
+++ b/Joystick.hpp
@@ -88,7 +88,7 @@ public:
     std::string GetName() const
     {
         if (_joy) {
-            return SDL_GameControllerName(_joy);
+            return SDL_JoystickName(_joy);
         } else {
             return "";
         }

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
 #include "ctre/phoenixpro/TalonFX.hpp"
 #include "RobotBase.hpp"
-#include "GameController.hpp"
+#include "Joystick.hpp"
 
 using namespace ctre::phoenixpro;
 
@@ -24,8 +24,8 @@ private:
     controls::DutyCycleOut leftOut{0};
     controls::DutyCycleOut rightOut{0};
 
-    /* game controller */
-    GameController joy{0};
+    /* joystick */
+    Joystick joy{0};
 
 public:
     /* main robot interface */
@@ -65,7 +65,7 @@ void Robot::RobotInit()
  */
 void Robot::RobotPeriodic()
 {
-    /* periodically check that the game controller is still good */
+    /* periodically check that the joystick is still good */
     joy.Periodic();
 }
 
@@ -74,8 +74,10 @@ void Robot::RobotPeriodic()
  */
 bool Robot::IsEnabled()
 {
-    /* enable while holding the right bumper */
-    return joy.GetButton(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER);
+    /* enable while joystick is an Xbox controller (6 axes),
+     * and we are holding the right bumper */
+    if (joy.GetNumAxes() < 6) return false;
+    return joy.GetButton(5); // SDL_CONTROLLER_BUTTON_RIGHTSHOULDER
 }
 
 /**
@@ -89,8 +91,8 @@ void Robot::EnabledInit() {}
 void Robot::EnabledPeriodic()
 {
     /* arcade drive */
-    double speed = -joy.GetAxis(SDL_CONTROLLER_AXIS_LEFTY);
-    double turn = joy.GetAxis(SDL_CONTROLLER_AXIS_RIGHTX);
+    double speed = -joy.GetAxis(1); // SDL_CONTROLLER_AXIS_LEFTY
+    double turn = joy.GetAxis(4); // SDL_CONTROLLER_AXIS_RIGHTX
 
     leftOut.Output = speed + turn;
     rightOut.Output = speed - turn;


### PR DESCRIPTION
Ubuntu 20.04 and older do not support SDL_GameController, so we need to add support for the old SDL_Joystick interface.