### PR TITLE
Add script to set up generic SocketCAN adapters when canivore-usb is not installed

### DIFF
--- a/generic_socketcan_start.sh
+++ b/generic_socketcan_start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Sets up a generic (non-CANivore) SocketCAN adapter for CAN 2.0.
+#
+# When the canivore-usb kernel module is installed, all SocketCAN
+# adapters are set up automatically by the robot program, and this
+# script should not be used.
+
+interface=can0
+if [ $# -gt 0 ]; then
+    interface=$1
+fi
+
+sudo ip link set $interface type can bitrate 1000000
+sudo ip link set $interface up
+sudo ip link set $interface txqueuelen 1000

--- a/readme.md
+++ b/readme.md
@@ -18,4 +18,4 @@ By default, the Joystick class is used for controller input. Users on Ubuntu 22.
 
 When the canivore-usb kernel module is installed (required when using CANivore), **all** SocketCAN adapters will be automatically started by the robot program.
 
-However, if it is not installed, then SocketCAN adapters must be manually brought up before running the robot program using `./generic_socketcan_start.sh [CAN network (default: can0)]`.
+However, if it is not installed, then SocketCAN adapters must be manually brought up before running the robot program using `./generic_socketcan_start.sh [CAN interface (default: can0)]`.

--- a/readme.md
+++ b/readme.md
@@ -13,3 +13,9 @@ By default, the Joystick class is used for controller input. Users on Ubuntu 22.
  3. Generate cmake `cmake ..`
  4. Make the code `make`
  5. Execute the code `./Phoenix6-Example`
+
+## Setting up Generic SocketCAN Adapters
+
+When the canivore-usb kernel module is installed (required when using CANivore), **all** SocketCAN adapters will be automatically started by the robot program.
+
+However, if it is not installed, then SocketCAN adapters must be manually brought up before running the robot program using `./generic_socketcan_start.sh [CAN network (default: can0)]`.


### PR DESCRIPTION
When canivore-usb is installed, this is done automatically, but if it is not, this script needs to be run.